### PR TITLE
added syndrome weight information

### DIFF
--- a/src/dist_m4ri.c
+++ b/src/dist_m4ri.c
@@ -237,7 +237,8 @@ int do_RW_dist(const csr_t * const spaH0, const csr_t * const spaL0,
 #ifdef STANDALONE
 
 int do_CC_dist(const csr_t * const mH, const csr_t * mL,
-	       const int wmax, const int start, const int debug);
+	       const int wmax, const int start, int p_swei[], const int debug);
+
 
 int main(int argc, char **argv){
   params_t * const p = &prm;
@@ -259,7 +260,7 @@ int main(int argc, char **argv){
   }
 
   if (prm.method & 2){ /* cluster method */
-    int dmin=do_CC_dist(p->spaH,p->spaL,p->wmax,p->start,p->debug);
+    int dmin=do_CC_dist(p->spaH,p->spaL,p->wmax,p->start,p->swei,p->debug);
 
     if (dmin>0){ 
       if (prm.debug&1)

--- a/src/util_io.c
+++ b/src/util_io.c
@@ -153,10 +153,7 @@ void var_init(int argc, char **argv, params_t * const p){
       ERROR("parameter steps=%d should be positive for RW method=%d", p->steps,p->method);
   }
   
-  if(p->method &2 ){ /* CC */
-    if (p->wmax<=0)
-      ERROR("parameter wmax=%d should be positive for CC method=%d", p->wmax,p->method);
-  }
+
 
   if((strlen(p->fin)!=0) && (!p->finH)){
     int len = strlen(p->fin);
@@ -189,6 +186,15 @@ void var_init(int argc, char **argv, params_t * const p){
   else
     ERROR("need to specify H=Hx input file name; use fin=[str] or finH=[str]\n");
 
+  if(p->method &2 ){ /* CC */
+    if (p->wmax<=0)
+      ERROR("parameter wmax=%d should be positive for CC method=%d", p->wmax,p->method);
+    if(p->wmax>=MAX_W)
+      ERROR("increase MAX_W=%d defined in 'util_io.h'",MAX_W);
+    for(int i=0; i<=p->wmax; i++)
+      p->swei[i]=p->spaH->rows +1; 
+  }
+  
 #if 0
   if (p->method&2){ /* cluster */
     p->max_row_wgt_H = csr_max_row_wght(p->spaH);

--- a/src/util_io.h
+++ b/src/util_io.h
@@ -22,6 +22,7 @@
 
 //static const int max_row_wt=10; 
 
+#define MAX_W 100 
 typedef struct{
   int debug; /* debug information */ 
   int classical; /* 1 for a classical code, i.e., no `G=Hz` matrix*/
@@ -37,6 +38,7 @@ typedef struct{
   int max_row_wgt_H; /* needed for C */
   int max_col_wgt_H; /* needed ? */
   //! int max_row_wt;  /* WARNING: this is defined in `util_io.h` as `static const int` */
+  int swei[MAX_W]; /** minimum syndrome weight for each error weight */
   int start;
   //  int linear; /* not supported */
   int n0;  /* code length, =nvar for css, (nvar/2) for non-css */


### PR DESCRIPTION
with `method=2` (exhaustive cluster enumeration) and `debug&2` non-zero, the program now displays minimum syndrome weight for each cluster (error) weight.